### PR TITLE
Remove extraneous params in utils

### DIFF
--- a/lambda/custom/utils/directives.js
+++ b/lambda/custom/utils/directives.js
@@ -30,14 +30,12 @@ const GameEngine = {
   startInputHandler: function ({
     timeout = RequiredParam('timeout'),
     proxies,
-    maximumHistoryLength,
     recognizers = RequiredParam('recognizers'),
     events = RequiredParam('events')
   } = {}, params) {
     return {
       "type": "GameEngine.StartInputHandler",
       "timeout": (params && params.timeout) || timeout,
-      "maximumHistoryLength": (params && params.maximumHistoryLength) || maximumHistoryLength,
       "proxies": (params && params.proxies) || proxies,
       "recognizers": (params && params.recognizers) || recognizers,
       "events": (params && params.events) || events,

--- a/lambda/custom/utils/rollcall.js
+++ b/lambda/custom/utils/rollcall.js
@@ -177,7 +177,7 @@ const rollCallHelper = {
     // 2) second pass through to see if there are any timeout events
     for (let eventIndex = 0; eventIndex < inputEvents.length; eventIndex++) {
       if (inputEvents[eventIndex].name == 'roll_call_timeout') {
-        rollCallHelper.handleRollCallTimeout(handlerInput, inputEvents[eventIndex]);
+        rollCallHelper.handleRollCallTimeout(handlerInput);
       }
     }
   },


### PR DESCRIPTION
*Description of changes:*
`maximumHistoryLength` isn't a thing; if it ever was, I can't find any references to it.
`rollCallHelper.handleRollCallTimeout` only takes a single parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
